### PR TITLE
CORE-536 Updated GH action and versions in README

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,10 +7,9 @@ jobs:
     name: Jira
     runs-on: ubuntu-latest
     steps:
-    - uses: openstax/jira-linked-action@v0.1.12
+    - uses: openstax/jira-linked-action@v0.1.13
       with:
         jira_site: openstax
         jira_project: DISCO
         jira_email: ${{ secrets.JiraEmail }}
         jira_token: ${{ secrets.JiraToken }}
-

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ jobs:
     name: Jira Issue
     runs-on: ubuntu-latest
     steps:
-    - uses: openstax/jira-linked-action@v0.1.12
+    - uses: openstax/jira-linked-action@v0.1.13
       with:
         jira_site: <jira subdomain> eg: openstx
         jira_project: <jira project> eg: DISCO
@@ -21,7 +21,7 @@ jobs:
 ```
 
 
-build and deply command:
+build and deploy command:
 ```
-export tag=v0.1.12 && test -z "$(git status --porcelain)" && git checkout -b "branch-$tag" && yarn build && git add -f dist && git commit -m "build $tag" && git tag "$tag" && git push --tags
+export tag=v0.1.13 && test -z "$(git status --porcelain)" && git checkout -b "branch-$tag" && yarn build && git add -f dist && git commit -m "build $tag" && git tag "$tag" && git push --tags
  ```


### PR DESCRIPTION
Just something I didn't do after the last release.

So, the last release's fix works for draft PRs, but maybe the linking doesn't happen fast enough so it seems to still fail at least once when the PR is created. We could add a small delay to the action or something like that...