### PR TITLE
CORE-536 Handle PR linking on first run

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ jobs:
     name: Jira
     runs-on: ubuntu-latest
     steps:
-    - uses: openstax/jira-linked-action@v0.1.13
+    - uses: openstax/jira-linked-action@v0.1.14
       with:
         jira_site: openstax
         jira_project: DISCO

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ jobs:
     name: Jira Issue
     runs-on: ubuntu-latest
     steps:
-    - uses: openstax/jira-linked-action@v0.1.13
+    - uses: openstax/jira-linked-action@v0.1.14
       with:
         jira_site: <jira subdomain> eg: openstx
         jira_project: <jira project> eg: DISCO
@@ -23,5 +23,5 @@ jobs:
 
 build and deploy command:
 ```
-export tag=v0.1.13 && test -z "$(git status --porcelain)" && git checkout -b "branch-$tag" && yarn build && git add -f dist && git commit -m "build $tag" && git tag "$tag" && git push --tags
+export tag=v0.1.14 && test -z "$(git status --porcelain)" && git checkout -b "branch-$tag" && yarn build && git add -f dist && git commit -m "build $tag" && git tag "$tag" && git push --tags
  ```

--- a/index.ts
+++ b/index.ts
@@ -109,5 +109,11 @@ const doCheck = async() => {
 };
 
 doCheck().catch(error => {
-  core.setFailed(error.message);
+  if (error.message === 'no matching issues found') {
+    return new Promise(resolve => setTimeout(resolve, 60000)).then(() => doCheck().catch(err => {
+      core.setFailed(err.message);
+    }));
+  } else {
+    core.setFailed(error.message);
+  }
 });


### PR DESCRIPTION
This PR just adds a retry after a 1 minute timeout, to give Jira time to link PRs when they are first created.